### PR TITLE
Ensure that the SnapDrawer respects the initial state set by the parent View

### DIFF
--- a/Sources/Snap/SnapDrawer.swift
+++ b/Sources/Snap/SnapDrawer.swift
@@ -34,7 +34,7 @@ public struct SnapDrawer<StateType: SnapState, Background : View, Content: View>
         self.state = state
         self.background = background
         self.content = content
-        self._currentResult = State(initialValue: calculator(state: .largeState))
+        self._currentResult = State(initialValue: calculator(state: state?.wrappedValue ?? .largeState))
         self.minDrag = self.calculator.results.first?.offset ?? 0
         self.maxDrag = self.calculator.results.last?.offset ?? 0
     }


### PR DESCRIPTION
Currently, I have the drawer in a `.tinyState` or invisible by default. I do so from my parent's initial `@State`. However, SnapDrawer starts out in its large form, even when a binding with its own initial value has already been set. This change ensures the initial value defined is derived from the binding _unless_ no binding is provided.